### PR TITLE
Add support for rich text and inline images

### DIFF
--- a/ConnectApiHelper.cls
+++ b/ConnectApiHelper.cls
@@ -1,10 +1,9 @@
 /*
-Copyright (c) 2014, salesforce.com, Inc.
+Copyright (c) 2015, salesforce.com, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
-
     * Redistributions of source code must retain the above copyright notice,
       this list of conditions and the following disclaimer.
     * Redistributions in binary form must reproduce the above copyright notice,
@@ -32,13 +31,13 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * Includes convenience methods to:
  *
- *     - Post Chatter @-mentions with Apex code.
+ *     - Post Chatter @-mentions, rich text, and inline images with Apex code.
  *     - Take a feed item or comment body and return an input body that matches it.
  *       This is useful for when you retrieve a feed item or comment and want to either
  *       re-post or edit it.
  *
- * This class works with API version 32.0 and later. There is a separate class
- * that works with v31.0 and earlier.
+ * This class works with API version 35.0 and later. There are separate classes
+ * that work with v34.0 and earlier.
  *
  * See https://github.com/alouie-sfdc/ConnectApiHelper for more information.
  *
@@ -47,7 +46,18 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
 global class ConnectApiHelper {
 
     public class InvalidParameterException extends Exception {}
-
+    
+    private static final Map<String, ConnectApi.MarkupType> supportedMarkup = new Map<String, ConnectApi.MarkupType> {
+        'b' => ConnectApi.MarkupType.Bold, 
+        'i' => ConnectApi.MarkupType.Italic, 
+        'li' => ConnectApi.MarkupType.ListItem, 
+        'ol' => ConnectApi.MarkupType.OrderedList, 
+        'p' => ConnectApi.MarkupType.Paragraph, 
+        's' => ConnectApi.MarkupType.Strikethrough, 
+        'u' => ConnectApi.MarkupType.Underline, 
+        'ul' => ConnectApi.MarkupType.UnorderedList
+    };
+    
     /**
      * Posts a feed item with @-mentions using an @-mention formatting syntax.
      * 
@@ -61,12 +71,36 @@ global class ConnectApiHelper {
      */
     public static ConnectApi.FeedElement postFeedItemWithMentions(String communityId, String subjectId, String textWithMentions) {
 
-        if (textWithMentions == null || textWithMentions.trim().length() == 0) {
-            throw new InvalidParameterException('The textWithMentions parameter must be non-empty.');
+        return postFeedItemWithSpecialFormatting(communityId, subjectId, textWithMentions, 'textWithMentions');
+    }
+
+    /**
+     * Posts a feed item with rich text using HTML tags and inline image formatting syntax.
+     * 
+     * @param communityId Use either the ID of a community, 'internal', or null.
+     * @param subjectId The parent of the post. Can be a user ID, a group ID, or a record ID.
+     * @param textWithMentionsAndRichText The text of the post. You can @-mention a
+     *                         user or group by using the syntax {ID}, for example: 
+     *                         'Hello {005x0000000URNP}, have you seen the group {0F9x00000000D7m}?' 
+     *                         You can include rich text by using supported HTML tags: 
+     *                         <b>, <i>, <u>, <s>, <ul>, <ol>, <li>, <p>.
+     *                         You can include an inline image by using the syntax {img:ID} or
+     *                         {img:ID:alt text}, for example: 'Have you seen this gorgeous view?
+     *                         {img:069x00000000D7m:View of the Space Needle from our office.}?' 
+     *                         Links and hashtags will be automatically parsed if provided.
+     * @return The posted feed item.
+     */
+    public static ConnectApi.FeedElement postFeedItemWithRichText(String communityId, String subjectId, String textWithMentionsAndRichText) {
+        return postFeedItemWithSpecialFormatting(communityId, subjectId, textWithMentionsAndRichText, 'textWithMentionsAndRichText');
+    }
+    
+    private static ConnectApi.FeedElement postFeedItemWithSpecialFormatting(String communityId, String subjectId, String formattedText, String textParameterName) {
+        if (formattedText == null || formattedText.trim().length() == 0) {
+            throw new InvalidParameterException('The ' + textParameterName + ' parameter must be non-empty.');
         }
         
         ConnectApi.MessageBodyInput messageInput = new ConnectApi.MessageBodyInput();
-        messageInput.messageSegments = getMessageSegmentInputs(textWithMentions);
+        messageInput.messageSegments = getMessageSegmentInputs(formattedText);
 
         ConnectApi.FeedItemInput input = new ConnectApi.FeedItemInput();
         input.body = messageInput;
@@ -108,35 +142,85 @@ global class ConnectApiHelper {
 
         List<ConnectApi.MessageSegmentInput> messageSegmentInputs = new List<ConnectApi.MessageSegmentInput>();
         Integer strPos = 0;
-        Pattern myPattern = Pattern.compile('\\{[a-zA-Z0-9]{15}\\}|\\{[a-zA-Z0-9]{18}\\}'); // Match a 15 or 18 character ID surrounded by {}.
-        Matcher myMatcher = myPattern.matcher(inputText);
+        // The pattern for matching mentions, markup begin/end tags, and inline images.
+        // The first group matches a 15 or 18 character ID surrounded by {}: 
+        //   (\\{[a-zA-Z0-9]{15}\\}|\\{[a-zA-Z0-9]{18}\\})
+        // The second/third groups match beginning/ending HTML tags: (<[a-zA-Z]*>)|(</[a-zA-Z]*>)
+        // The fourth group matches a 15 or 18 character content document ID preceded by "img:", 
+        //    optionally followed by a string (not containing '}'), and surrounded by {}: 
+        //    (\\{img:(069[a-zA-Z0-9]{12,15})(:[\\s\\S]*?)?\\})
+        Pattern globalPattern = Pattern.compile('(\\{[a-zA-Z0-9]{15}\\}|\\{[a-zA-Z0-9]{18}\\})|(<[a-zA-Z]*>)|(</[a-zA-Z]*>)|(\\{img:(069[a-zA-Z0-9]{12,15})(:[\\s\\S]*?)?\\})');
+        Matcher globalMatcher = globalPattern.matcher(inputText);
         
-        while (myMatcher.find()) {
-              String textSegment = inputText.substring(strPos, myMatcher.start());
-              String mentionId = myMatcher.group();
-              // Strip off the { and }.
-              mentionId = mentionId.substring(1, mentionId.length() - 1);
-              strPos = myMatcher.end();
-              
-              if (textSegment != null && textSegment.length() > 0) {
-                  ConnectApi.TextSegmentInput textSegmentInput = makeTextSegmentInput(textSegment);
-                  messageSegmentInputs.add(textSegmentInput);
-              }
-              
-              ConnectApi.MentionSegmentInput mentionSegmentInput = makeMentionSegmentInput(mentionId);
-              messageSegmentInputs.add(mentionSegmentInput);
-        }
+        while (globalMatcher.find()) {
+            String textSegment = inputText.substring(strPos, globalMatcher.start());
+            String matchingText = globalMatcher.group();
+            if (matchingText.startsWith('{')) {
+                // Add a segment for any accumulated text (which includes unsupported HTML tags).
+                addTextSegment(messageSegmentInputs, textSegment); 
 
-        // Take care of any text that comes after the last mention.
-        if (strPos < inputText.length()) {
-            String trailingText = inputText.substring(strPos, inputText.length());
-            if (trailingText != null && trailingText.length() > 0) {
-                ConnectApi.TextSegmentInput textSegmentInput = makeTextSegmentInput(trailingText);
-                messageSegmentInputs.add(textSegmentInput);
+                // Strip off the { and }.
+                String innerMatchedText = matchingText.substring(1, matchingText.length() - 1);
+
+                if (innerMatchedText.startsWith('img:')) {
+                    // This is an inline image.
+                    String[] imageInfo = innerMatchedText.split(':', 3);
+                    String altText = imageInfo.size() == 3 ? imageInfo[2] : null;
+                    ConnectApi.InlineImageSegmentInput inlineImageSegmentInput = makeInlineImageSegmentInput(imageInfo[1], altText);
+                    messageSegmentInputs.add(inlineImageSegmentInput);
+                    strPos = globalMatcher.end();
+                }
+                else {
+                    // This is a mention id.
+                    ConnectApi.MentionSegmentInput mentionSegmentInput = makeMentionSegmentInput(innerMatchedText);
+                    messageSegmentInputs.add(mentionSegmentInput);
+                    strPos = globalMatcher.end();
+                }
+            }
+            else {
+                // This is an HTML tag.
+                boolean isBeginTag = !matchingText.startsWith('</');
+                if (isBeginTag) {
+                    // Strip off the < and >.
+                    String tag = matchingText.substring(1, matchingText.indexOf('>'));
+                    if (supportedMarkup.containsKey(tag.toLowerCase())) {
+                        // Add a segment for any accumulated text (which includes unsupported HTML tags).
+                        addTextSegment(messageSegmentInputs, textSegment); 
+                        
+                        ConnectApi.MarkupBeginSegmentInput markupBeginSegmentInput = makeMarkupBeginSegmentInput(tag);
+                        messageSegmentInputs.add(markupBeginSegmentInput);
+                        strPos = globalMatcher.end();
+                    }
+                }
+                else { // This is an end tag.
+                    // Strip off the </ and >.
+                    String tag = matchingText.substring(2, matchingText.indexOf('>'));
+                    if (supportedMarkup.containsKey(tag.toLowerCase())) {
+                        // Add a segment for any accumulated text (which includes unsupported HTML tags).
+                        addTextSegment(messageSegmentInputs, textSegment); 
+
+                        ConnectApi.MarkupEndSegmentInput markupEndSegmentInput = makeMarkupEndSegmentInput(tag);
+                        messageSegmentInputs.add(markupEndSegmentInput);
+                        strPos = globalMatcher.end();
+                    }
+                }
             }
         }
 
+        // Take care of any text that comes after the last match.
+        if (strPos < inputText.length()) {
+            String trailingText = inputText.substring(strPos, inputText.length());
+            addTextSegment(messageSegmentInputs, trailingText);
+        }
+
         return messageSegmentInputs;
+    }
+
+    private static void addTextSegment(List<ConnectApi.MessageSegmentInput> messageSegmentInputs, String text) {
+        if (text != null && text.length() > 0) {
+            ConnectApi.TextSegmentInput textSegmentInput = makeTextSegmentInput(text);
+            messageSegmentInputs.add(textSegmentInput);
+        }
     }
 
     private static ConnectApi.TextSegmentInput makeTextSegmentInput(String text) {
@@ -149,6 +233,35 @@ global class ConnectApiHelper {
         ConnectApi.MentionSegmentInput mentionSegment = new ConnectApi.MentionSegmentInput();
         mentionSegment.id = mentionId;
         return mentionSegment;
+    }
+    
+    /**
+     * Create a MarkupBeginSegmentInput corresponding to the tag.  Checking whether the tag is 
+     * supported markup should happen before calling this method.
+     */
+    private static ConnectApi.MarkupBeginSegmentInput makeMarkupBeginSegmentInput(String tag) {
+        ConnectApi.MarkupBeginSegmentInput markupBeginSegment = new ConnectApi.MarkupBeginSegmentInput();
+        markupBeginSegment.markupType = supportedMarkup.get(tag.toLowerCase());
+        return markupBeginSegment;
+    }
+    
+    /**
+     * Create a MarkupEndSegmentInput corresponding to the tag.  Checking whether the tag is 
+     * supported markup should happen before calling this method.
+     */
+    private static ConnectApi.MarkupEndSegmentInput makeMarkupEndSegmentInput(String tag) {
+        ConnectApi.MarkupEndSegmentInput markupEndSegment = new ConnectApi.MarkupEndSegmentInput();
+        markupEndSegment.markupType = supportedMarkup.get(tag.toLowerCase());
+        return markupEndSegment;
+    }
+    
+    private static ConnectApi.InlineImageSegmentInput makeInlineImageSegmentInput(String fileId, String altText) {
+        ConnectApi.InlineImageSegmentInput inlineImageSegment = new ConnectApi.InlineImageSegmentInput();
+        inlineImageSegment.fileId = fileId;
+        if (String.isNotBlank(altText)) {
+            inlineImageSegment.altText = altText;
+        }
+        return inlineImageSegment;
     }
     
     /**
@@ -184,6 +297,25 @@ global class ConnectApiHelper {
                 linkInput.url = linkOutput.url;
                 input.messageSegments.add(linkInput);
             }
+            else if (segment instanceof ConnectApi.MarkupBeginSegment) {
+                ConnectApi.MarkupBeginSegment markupBeginOutput = (ConnectApi.MarkupBeginSegment) segment;
+                ConnectApi.MarkupBeginSegmentInput markupBeginInput = new ConnectApi.MarkupBeginSegmentInput();
+                markupBeginInput.markupType = markupBeginOutput.markupType;
+                input.messageSegments.add(markupBeginInput);
+            }
+            else if (segment instanceof ConnectApi.MarkupEndSegment) {
+                ConnectApi.MarkupEndSegment markupEndOutput = (ConnectApi.MarkupEndSegment) segment;
+                ConnectApi.MarkupEndSegmentInput markupEndInput = new ConnectApi.MarkupEndSegmentInput();
+                markupEndInput.markupType = markupEndOutput.markupType;
+                input.messageSegments.add(markupEndInput);
+            }
+            else if (segment instanceof ConnectApi.InlineImageSegment) {
+                ConnectApi.InlineImageSegment inlineImageOutput = (ConnectApi.InlineImageSegment) segment;
+                ConnectApi.InlineImageSegmentInput inlineImageInput = new ConnectApi.InlineImageSegmentInput();
+                inlineImageInput.fileId = inlineImageOutput.thumbnails.fileId;
+                inlineImageInput.altText = inlineImageOutput.altText;
+                input.messageSegments.add(inlineImageInput);
+            }
             else {
                 // The other segment types are system-generated and have no corresponding input types.
             }
@@ -215,5 +347,4 @@ global class ConnectApiHelper {
         input.body = bodyInput;
         return input;
     }
-        
 }

--- a/ConnectApiHelperTest.cls
+++ b/ConnectApiHelperTest.cls
@@ -1,10 +1,9 @@
 /*
-Copyright (c) 2014, salesforce.com, Inc.
+Copyright (c) 2015, salesforce.com, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
-
     * Redistributions of source code must retain the above copyright notice,
       this list of conditions and the following disclaimer.
     * Redistributions in binary form must reproduce the above copyright notice,
@@ -30,8 +29,8 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * Unit tests for ConnectApiHelper.
  *
- * This class works with API version 32.0 and later. There is a separate class
- * that works with v31.0 and earlier.
+ * This class works with API version 35.0 and later. There are separate classes
+ * that work with v34.0 and earlier.
  *
  * See https://github.com/alouie-sfdc/ConnectApiHelper for more information.
  *
@@ -168,7 +167,7 @@ public class ConnectApiHelperTest {
         String text3 = ' test.';
         String text = '#' + hashtag + text1 + link + text2 + '{' + mentionId + '}' + text3;
         
-        ConnectApi.FeedElement fi = ConnectApiHelper.postFeedItemWithMentions(null, 'me', text);
+        ConnectApi.FeedElement fi = ConnectApiHelper.postFeedItemWithRichText(null, 'me', text);
         
         List<ConnectApi.MessageSegment> segments = fi.body.messageSegments;
 
@@ -216,8 +215,8 @@ public class ConnectApiHelperTest {
     @IsTest(SeeAllData=true)
     static void testCreateInputFromBody() {
     
-        // We'll post a feed item that contains text, link, hashtag, and mention segments, and then call the helper method on the
-        // resulting body.
+        // We'll post a feed item that contains text, link, hashtag, mention, and markup segments, 
+        // and then call the helper method on the resulting body.
 
         ConnectApi.FeedItemInput feedItemInput = new ConnectApi.FeedItemInput();
 
@@ -229,6 +228,7 @@ public class ConnectApiHelperTest {
         String expectedText = 'Text ';
         String expectedLink = 'http://link.com';
         String expectedHashtag = 'hashtag';
+        String expectedBoldText = 'Bold text';
 
         ConnectApi.TextSegmentInput textSegmentInput = new ConnectApi.TextSegmentInput();
         textSegmentInput.text = expectedText + expectedLink + ' #' + expectedHashtag;
@@ -237,6 +237,18 @@ public class ConnectApiHelperTest {
         ConnectApi.MentionSegmentInput mentionSegmentInput = new ConnectApi.MentionSegmentInput();
         mentionSegmentInput.id = UserInfo.getUserId();
         messageBodyInput.messageSegments.add(mentionSegmentInput);
+        
+        ConnectApi.MarkupBeginSegmentInput markupBeginSegmentInput = new ConnectApi.MarkupBeginSegmentInput();
+        markupBeginSegmentInput.markupType = ConnectApi.MarkupType.Bold;
+        messageBodyInput.messageSegments.add(markupBeginSegmentInput);
+        
+        textSegmentInput = new ConnectApi.TextSegmentInput();
+        textSegmentInput.text = expectedBoldText;
+        messageBodyInput.messageSegments.add(textSegmentInput);
+
+        ConnectApi.MarkupEndSegmentInput markupEndSegmentInput = new ConnectApi.MarkupEndSegmentInput();
+        markupEndSegmentInput.markupType = ConnectApi.MarkupType.Bold;
+        messageBodyInput.messageSegments.add(markupEndSegmentInput);
 
         feedItemInput.body = messageBodyInput;
         feedItemInput.feedElementType = ConnectApi.FeedElementType.FeedItem;
@@ -245,7 +257,7 @@ public class ConnectApiHelperTest {
         ConnectApi.FeedElement feedElement = ConnectApi.ChatterFeeds.postFeedElement(Network.getNetworkId(), feedItemInput, null);
         
         ConnectApi.MessageBodyInput input = ConnectApiHelper.createInputFromBody(feedElement.body);
-        System.assertEquals(5, input.messageSegments.size(), 'Wrong number of message segments.');
+        System.assertEquals(8, input.messageSegments.size(), 'Wrong number of message segments.');
 
         System.assert(input.messageSegments.get(0) instanceof ConnectApi.TextSegmentInput, 'Segment 0 is not a text segment input.');
         ConnectApi.TextSegmentInput textInput = (ConnectApi.TextSegmentInput) input.messageSegments.get(0);
@@ -266,6 +278,18 @@ public class ConnectApiHelperTest {
         System.assert(input.messageSegments.get(4) instanceof ConnectApi.MentionSegmentInput, 'Segment 4 is not a mention segment input.');
         ConnectApi.MentionSegmentInput mentionInput = (ConnectApi.MentionSegmentInput) input.messageSegments.get(4);
         System.assertEquals(UserInfo.getUserId(), mentionInput.id, 'Segment 4 mention ID does not match.');
+
+        System.assert(input.messageSegments.get(5) instanceof ConnectApi.MarkupBeginSegmentInput, 'Segment 5 is not a markup begin segment input.');
+        ConnectApi.MarkupBeginSegmentInput markupBeginInput = (ConnectApi.MarkupBeginSegmentInput) input.messageSegments.get(5);
+        System.assertEquals(ConnectApi.MarkupType.Bold, markupBeginInput.markupType, 'Segment 5 markup type does not match.');
+
+        System.assert(input.messageSegments.get(6) instanceof ConnectApi.TextSegmentInput, 'Segment 6 is not a text segment input.');
+        ConnectApi.TextSegmentInput textInput3 = (ConnectApi.TextSegmentInput) input.messageSegments.get(6);
+        System.assertEquals(expectedBoldText, textInput3.text, 'Segment 6 text does not match.');
+
+        System.assert(input.messageSegments.get(7) instanceof ConnectApi.MarkupEndSegmentInput, 'Segment 7 is not a markup end segment input.');
+        ConnectApi.MarkupEndSegmentInput markupEndInput = (ConnectApi.MarkupEndSegmentInput) input.messageSegments.get(7);
+        System.assertEquals(ConnectApi.MarkupType.Bold, markupEndInput.markupType, 'Segment 7 markup type does not match.');
 
         // Get coverage for the createFeedItemInputFromBody() method.
         ConnectApi.FeedItemInput feedItemInput2 = ConnectApiHelper.createFeedItemInputFromBody(feedElement.body);
@@ -292,4 +316,353 @@ public class ConnectApiHelperTest {
         System.assertEquals(0, input.messageSegments.size(), 'Wrong number of message segments.');
     }
 
+
+    @IsTest(SeeAllData=true)
+    static void testUnsupportedMarkup() {
+        // <span>a</span>, <h1><a>b</a> <br> <b>Does this work?</b></h1>
+        // [0                               ][1][2            ][3 ][4  ]
+        // 0 = text1
+        // 1 = markup begin
+        // 2 = text2
+        // 3 = markup end
+        // 4 = text3
+        String text1 = '<span>a</span>, <h1><a>b</a> <br> ';
+        String text2 = 'Does this work?';
+        String text3 = '</h1>';
+        String text = text1 + '<b>' + text2 + '</b>' + text3;
+
+        List<ConnectApi.MessageSegmentInput> segments = ConnectApiHelper.getMessageSegmentInputs(text);
+
+        System.assertEquals(5, segments.size());
+        System.assert(segments.get(0) instanceof ConnectApi.TextSegmentInput);
+        System.assert(segments.get(1) instanceof ConnectApi.MarkupBeginSegmentInput);
+        System.assert(segments.get(2) instanceof ConnectApi.TextSegmentInput);
+        System.assert(segments.get(3) instanceof ConnectApi.MarkupEndSegmentInput);
+        System.assert(segments.get(4) instanceof ConnectApi.TextSegmentInput);
+
+        ConnectApi.TextSegmentInput textSegment = (ConnectApi.TextSegmentInput) segments.get(0);
+        System.assertEquals(text1, textSegment.text);
+
+        ConnectApi.MarkupBeginSegmentInput markupBeginSegment = (ConnectApi.MarkupBeginSegmentInput) segments.get(1);
+        System.assertEquals(ConnectApi.MarkupType.Bold, markupBeginSegment.markupType);
+
+        textSegment = (ConnectApi.TextSegmentInput) segments.get(2);
+        System.assertEquals(text2, textSegment.text);
+
+        ConnectApi.MarkupEndSegmentInput markupEndSegment = (ConnectApi.MarkupEndSegmentInput) segments.get(3);
+        System.assertEquals(ConnectApi.MarkupType.Bold, markupEndSegment.markupType);
+
+        textSegment = (ConnectApi.TextSegmentInput) segments.get(4);
+        System.assertEquals(text3, textSegment.text);
+    }
+
+    @IsTest(SeeAllData=true)
+    static void testSimpleMarkup() {
+        String restOfMessage = 'blah';
+        String text = '<u>' + restOfMessage + '</u>';
+        List<ConnectApi.MessageSegmentInput> segments = ConnectApiHelper.getMessageSegmentInputs(text);
+
+        System.assertEquals(3, segments.size());
+        System.assert(segments.get(0) instanceof ConnectApi.MarkupBeginSegmentInput);
+        System.assert(segments.get(1) instanceof ConnectApi.TextSegmentInput);
+        System.assert(segments.get(2) instanceof ConnectApi.MarkupEndSegmentInput);
+
+        ConnectApi.MarkupBeginSegmentInput markupBeginSegment = (ConnectApi.MarkupBeginSegmentInput) segments.get(0);
+        System.assertEquals(ConnectApi.MarkupType.Underline, markupBeginSegment.markupType);
+
+        ConnectApi.TextSegmentInput textSegment = (ConnectApi.TextSegmentInput) segments.get(1);
+        System.assertEquals(restOfMessage, textSegment.text);
+
+        ConnectApi.MarkupEndSegmentInput markupEndSegment = (ConnectApi.MarkupEndSegmentInput) segments.get(2);
+        System.assertEquals(ConnectApi.MarkupType.Underline, markupEndSegment.markupType);
+    }
+
+    @IsTest(SeeAllData=true)
+    static void testMarkupCasing() {
+        String text1 = 'foo';
+        String text2 = 'bar';
+        String text3 = 'baz';
+        String text = '<U>' + text1 + '</U><b>' + text2 + '</B><oL><li>' + text3 + '</li></oL>';
+        List<ConnectApi.MessageSegmentInput> segments = ConnectApiHelper.getMessageSegmentInputs(text);
+
+        System.assertEquals(11, segments.size());
+        System.assert(segments.get(0) instanceof ConnectApi.MarkupBeginSegmentInput);
+        System.assert(segments.get(1) instanceof ConnectApi.TextSegmentInput);
+        System.assert(segments.get(2) instanceof ConnectApi.MarkupEndSegmentInput);
+        System.assert(segments.get(3) instanceof ConnectApi.MarkupBeginSegmentInput);
+        System.assert(segments.get(4) instanceof ConnectApi.TextSegmentInput);
+        System.assert(segments.get(5) instanceof ConnectApi.MarkupEndSegmentInput);
+        System.assert(segments.get(6) instanceof ConnectApi.MarkupBeginSegmentInput);
+        System.assert(segments.get(7) instanceof ConnectApi.MarkupBeginSegmentInput);
+        System.assert(segments.get(8) instanceof ConnectApi.TextSegmentInput);
+        System.assert(segments.get(9) instanceof ConnectApi.MarkupEndSegmentInput);
+        System.assert(segments.get(10) instanceof ConnectApi.MarkupEndSegmentInput);
+
+        ConnectApi.MarkupBeginSegmentInput markupBeginSegment = (ConnectApi.MarkupBeginSegmentInput) segments.get(0);
+        System.assertEquals(ConnectApi.MarkupType.Underline, markupBeginSegment.markupType);
+
+        ConnectApi.TextSegmentInput textSegment = (ConnectApi.TextSegmentInput) segments.get(1);
+        System.assertEquals(text1, textSegment.text);
+
+        ConnectApi.MarkupEndSegmentInput markupEndSegment = (ConnectApi.MarkupEndSegmentInput) segments.get(2);
+        System.assertEquals(ConnectApi.MarkupType.Underline, markupEndSegment.markupType);
+
+        markupBeginSegment = (ConnectApi.MarkupBeginSegmentInput) segments.get(3);
+        System.assertEquals(ConnectApi.MarkupType.Bold, markupBeginSegment.markupType);
+
+        textSegment = (ConnectApi.TextSegmentInput) segments.get(4);
+        System.assertEquals(text2, textSegment.text);
+
+        markupEndSegment = (ConnectApi.MarkupEndSegmentInput) segments.get(5);
+        System.assertEquals(ConnectApi.MarkupType.Bold, markupEndSegment.markupType);
+
+        markupBeginSegment = (ConnectApi.MarkupBeginSegmentInput) segments.get(6);
+        System.assertEquals(ConnectApi.MarkupType.OrderedList, markupBeginSegment.markupType);
+
+        markupBeginSegment = (ConnectApi.MarkupBeginSegmentInput) segments.get(7);
+        System.assertEquals(ConnectApi.MarkupType.ListItem, markupBeginSegment.markupType);
+
+        textSegment = (ConnectApi.TextSegmentInput) segments.get(8);
+        System.assertEquals(text3, textSegment.text);
+
+        markupEndSegment = (ConnectApi.MarkupEndSegmentInput) segments.get(9);
+        System.assertEquals(ConnectApi.MarkupType.ListItem, markupEndSegment.markupType);
+        
+        markupEndSegment = (ConnectApi.MarkupEndSegmentInput) segments.get(10);
+        System.assertEquals(ConnectApi.MarkupType.OrderedList, markupEndSegment.markupType);
+    }
+
+    @IsTest(SeeAllData=true)
+    static void testInlineImage() {
+        String restOfMessage = 'Check out this image!';
+        String imageId = '069B0000000q7hi';
+        String altText = 'Some alt text.';
+        String text = restOfMessage + '{img:' + imageId + ':' + altText + '}';
+        List<ConnectApi.MessageSegmentInput> segments = ConnectApiHelper.getMessageSegmentInputs(text);
+
+        System.assertEquals(2, segments.size());
+        System.assert(segments.get(0) instanceof ConnectApi.TextSegmentInput);
+        System.assert(segments.get(1) instanceof ConnectApi.InlineImageSegmentInput);
+
+        ConnectApi.TextSegmentInput textSegment = (ConnectApi.TextSegmentInput) segments.get(0);
+        System.assertEquals(restOfMessage, textSegment.text);
+
+        ConnectApi.InlineImageSegmentInput inlineImageSegment = (ConnectApi.InlineImageSegmentInput) segments.get(1);
+        System.assertEquals(imageId, inlineImageSegment.fileId);
+        System.assertEquals(altText, inlineImageSegment.altText);
+    }
+
+    @IsTest(SeeAllData=true)
+    static void testInlineImageNoAltText() {
+        String imageId = '069B0000000q7hi';
+        String text = '{img:' + imageId + '}';
+        List<ConnectApi.MessageSegmentInput> segments = ConnectApiHelper.getMessageSegmentInputs(text);
+
+        System.assertEquals(1, segments.size());
+        System.assert(segments.get(0) instanceof ConnectApi.InlineImageSegmentInput);
+
+        ConnectApi.InlineImageSegmentInput inlineImageSegment = (ConnectApi.InlineImageSegmentInput) segments.get(0);
+        System.assertEquals(imageId, inlineImageSegment.fileId);
+        System.assertEquals(null, inlineImageSegment.altText);
+    }
+
+    @IsTest(SeeAllData=true)
+    static void testInlineImageAltTextSyntax() {
+        String imageId15 = '069B0000000q7hi';
+        String imageId18 = '069B0000000q7hixxx';
+        String altText1 = 'Alt text with a colon : in the middle.';
+        String badSyntax1 = 'Alt text with a closing brace ';
+        String badSyntax2 = ' in the middle.}';
+        String badSyntaxAltText = badSyntax1 + '}' + badSyntax2;
+        String text = '{img:' + imageId15 + ':' + altText1 + '}{img:' + imageId18 + ':}{img:' + imageId15 + ':' + badSyntaxAltText;
+        List<ConnectApi.MessageSegmentInput> segments = ConnectApiHelper.getMessageSegmentInputs(text);
+
+        System.assertEquals(4, segments.size());
+        System.assert(segments.get(0) instanceof ConnectApi.InlineImageSegmentInput);
+        System.assert(segments.get(1) instanceof ConnectApi.InlineImageSegmentInput);
+        System.assert(segments.get(2) instanceof ConnectApi.InlineImageSegmentInput);
+        System.assert(segments.get(3) instanceof ConnectApi.TextSegmentInput);
+
+        ConnectApi.InlineImageSegmentInput inlineImageSegment = (ConnectApi.InlineImageSegmentInput) segments.get(0);
+        System.assertEquals(imageId15, inlineImageSegment.fileId);
+        System.assertEquals(altText1, inlineImageSegment.altText);
+
+        inlineImageSegment = (ConnectApi.InlineImageSegmentInput) segments.get(1);
+        System.assertEquals(imageId18, inlineImageSegment.fileId);
+        System.assertEquals(null, inlineImageSegment.altText);
+
+        inlineImageSegment = (ConnectApi.InlineImageSegmentInput) segments.get(2);
+        System.assertEquals(imageId15, inlineImageSegment.fileId);
+        System.assertEquals(badSyntax1, inlineImageSegment.altText);
+
+        ConnectApi.TextSegmentInput textSegment = (ConnectApi.TextSegmentInput) segments.get(3);
+        System.assertEquals(badSyntax2, textSegment.text);
+    }
+
+    @IsTest(SeeAllData=true)
+    static void testMarkupAndMention() {
+        String mentionId = '005x0000000URNPzzz';
+        String message = 'How are you';
+        String questionMark = '?';
+        String text = '<b>' + message + '<i>{' + mentionId + '}</i>' + questionMark + '</b>';
+        List<ConnectApi.MessageSegmentInput> segments = ConnectApiHelper.getMessageSegmentInputs(text);
+
+        System.assertEquals(7, segments.size());
+        System.assert(segments.get(0) instanceof ConnectApi.MarkupBeginSegmentInput);
+        System.assert(segments.get(1) instanceof ConnectApi.TextSegmentInput);
+        System.assert(segments.get(2) instanceof ConnectApi.MarkupBeginSegmentInput);
+        System.assert(segments.get(3) instanceof ConnectApi.MentionSegmentInput);
+        System.assert(segments.get(4) instanceof ConnectApi.MarkupEndSegmentInput);
+        System.assert(segments.get(5) instanceof ConnectApi.TextSegmentInput);
+        System.assert(segments.get(6) instanceof ConnectApi.MarkupEndSegmentInput);
+
+        ConnectApi.MarkupBeginSegmentInput markupBeginSegment = (ConnectApi.MarkupBeginSegmentInput) segments.get(0);
+        System.assertEquals(ConnectApi.MarkupType.Bold, markupBeginSegment.markupType);
+
+        ConnectApi.TextSegmentInput textSegment = (ConnectApi.TextSegmentInput) segments.get(1);
+        System.assertEquals(message, textSegment.text);
+
+        markupBeginSegment = (ConnectApi.MarkupBeginSegmentInput) segments.get(2);
+        System.assertEquals(ConnectApi.MarkupType.Italic, markupBeginSegment.markupType);
+
+        ConnectApi.MentionSegmentInput mentionSegment = (ConnectApi.MentionSegmentInput) segments.get(3);
+        System.assertEquals(mentionId, mentionSegment.id);
+
+        ConnectApi.MarkupEndSegmentInput markupEndSegment = (ConnectApi.MarkupEndSegmentInput) segments.get(4);
+        System.assertEquals(ConnectApi.MarkupType.Italic, markupEndSegment.markupType);
+
+        textSegment = (ConnectApi.TextSegmentInput) segments.get(5);
+        System.assertEquals(questionMark, textSegment.text);
+
+        markupEndSegment = (ConnectApi.MarkupEndSegmentInput) segments.get(6);
+        System.assertEquals(ConnectApi.MarkupType.Bold, markupEndSegment.markupType);
+    }
+
+    @IsTest(SeeAllData=true)
+    static void testAllMarkupAndInlineImage() {
+        // <p><i>This is an italicized paragraph.</i></p>
+        // <ul><li><s>A completed item in an unordered list.</s></li></ul>
+        // <ol><li><u>An underlined item in an ordered list.</u></li></ol>
+        // <b>And, of course, an image for you:</b> {img:069B0000000q7hi:An image of something nice.}
+        String text1 = 'This is an italicized paragraph.';
+        String text2 = 'A completed item in an unordered list.';
+        String text3 = 'An underlined item in an ordered list.';
+        String text4 = 'And, of course, an image for you: ';
+        String text5 = ' ';
+        String imageId = '069B0000000q7hi';
+        String altText = 'An image of something nice.';
+        String text = '<p><i>' + text1 + '</i></p><ul><li><s>' + text2 + '</s></li></ul><ol><li><u>' 
+                        + text3 + '</u></li></ol><b>' + text4 + '</b> {img:' + imageId + ':' + altText + '}';
+        List<ConnectApi.MessageSegmentInput> segments = ConnectApiHelper.getMessageSegmentInputs(text);
+
+        System.assertEquals(24, segments.size());
+        // <p><i>This is an italicized paragraph.</i></p>
+        System.assert(segments.get(0) instanceof ConnectApi.MarkupBeginSegmentInput);
+        System.assert(segments.get(1) instanceof ConnectApi.MarkupBeginSegmentInput);
+        System.assert(segments.get(2) instanceof ConnectApi.TextSegmentInput);
+        System.assert(segments.get(3) instanceof ConnectApi.MarkupEndSegmentInput);
+        System.assert(segments.get(4) instanceof ConnectApi.MarkupEndSegmentInput);
+        
+        // <ul><li><s>A completed item in an unordered list.</s></li></ul>        
+        System.assert(segments.get(5) instanceof ConnectApi.MarkupBeginSegmentInput);
+        System.assert(segments.get(6) instanceof ConnectApi.MarkupBeginSegmentInput);
+        System.assert(segments.get(7) instanceof ConnectApi.MarkupBeginSegmentInput);
+        System.assert(segments.get(8) instanceof ConnectApi.TextSegmentInput);
+        System.assert(segments.get(9) instanceof ConnectApi.MarkupEndSegmentInput);
+        System.assert(segments.get(10) instanceof ConnectApi.MarkupEndSegmentInput);
+        System.assert(segments.get(11) instanceof ConnectApi.MarkupEndSegmentInput);
+        
+        // <ol><li><u>An underlined item in an ordered list.</u></li></ol>
+        System.assert(segments.get(12) instanceof ConnectApi.MarkupBeginSegmentInput);
+        System.assert(segments.get(13) instanceof ConnectApi.MarkupBeginSegmentInput);
+        System.assert(segments.get(14) instanceof ConnectApi.MarkupBeginSegmentInput);
+        System.assert(segments.get(15) instanceof ConnectApi.TextSegmentInput);
+        System.assert(segments.get(16) instanceof ConnectApi.MarkupEndSegmentInput);
+        System.assert(segments.get(17) instanceof ConnectApi.MarkupEndSegmentInput);
+        System.assert(segments.get(18) instanceof ConnectApi.MarkupEndSegmentInput);
+        
+        // <b>And, of course, an image for you:</b> {img:069B0000000q7hi:An image of something nice.}
+        System.assert(segments.get(19) instanceof ConnectApi.MarkupBeginSegmentInput);
+        System.assert(segments.get(20) instanceof ConnectApi.TextSegmentInput);
+        System.assert(segments.get(21) instanceof ConnectApi.MarkupEndSegmentInput);
+        System.assert(segments.get(22) instanceof ConnectApi.TextSegmentInput);
+        System.assert(segments.get(23) instanceof ConnectApi.InlineImageSegmentInput);
+
+        // <p><i>This is an italicized paragraph.</i></p>
+        ConnectApi.MarkupBeginSegmentInput markupBeginSegment = (ConnectApi.MarkupBeginSegmentInput) segments.get(0);
+        System.assertEquals(ConnectApi.MarkupType.Paragraph, markupBeginSegment.markupType);
+
+        markupBeginSegment = (ConnectApi.MarkupBeginSegmentInput) segments.get(1);
+        System.assertEquals(ConnectApi.MarkupType.Italic, markupBeginSegment.markupType);
+
+        ConnectApi.TextSegmentInput textSegment = (ConnectApi.TextSegmentInput) segments.get(2);
+        System.assertEquals(text1, textSegment.text);
+
+        ConnectApi.MarkupEndSegmentInput markupEndSegment = (ConnectApi.MarkupEndSegmentInput) segments.get(3);
+        System.assertEquals(ConnectApi.MarkupType.Italic, markupEndSegment.markupType);
+
+        markupEndSegment = (ConnectApi.MarkupEndSegmentInput) segments.get(4);
+        System.assertEquals(ConnectApi.MarkupType.Paragraph, markupEndSegment.markupType);
+
+        // <ul><li><s>A completed item in an unordered list.</s></li></ul>        
+        markupBeginSegment = (ConnectApi.MarkupBeginSegmentInput) segments.get(5);
+        System.assertEquals(ConnectApi.MarkupType.UnorderedList, markupBeginSegment.markupType);
+
+        markupBeginSegment = (ConnectApi.MarkupBeginSegmentInput) segments.get(6);
+        System.assertEquals(ConnectApi.MarkupType.ListItem, markupBeginSegment.markupType);
+
+        markupBeginSegment = (ConnectApi.MarkupBeginSegmentInput) segments.get(7);
+        System.assertEquals(ConnectApi.MarkupType.Strikethrough, markupBeginSegment.markupType);
+
+        textSegment = (ConnectApi.TextSegmentInput) segments.get(8);
+        System.assertEquals(text2, textSegment.text);
+
+        markupEndSegment = (ConnectApi.MarkupEndSegmentInput) segments.get(9);
+        System.assertEquals(ConnectApi.MarkupType.Strikethrough, markupEndSegment.markupType);
+
+        markupEndSegment = (ConnectApi.MarkupEndSegmentInput) segments.get(10);
+        System.assertEquals(ConnectApi.MarkupType.ListItem, markupEndSegment.markupType);
+
+        markupEndSegment = (ConnectApi.MarkupEndSegmentInput) segments.get(11);
+        System.assertEquals(ConnectApi.MarkupType.UnorderedList, markupEndSegment.markupType);
+
+        // <ol><li><u>An underlined item in an ordered list.</u></li></ol>
+        markupBeginSegment = (ConnectApi.MarkupBeginSegmentInput) segments.get(12);
+        System.assertEquals(ConnectApi.MarkupType.OrderedList, markupBeginSegment.markupType);
+
+        markupBeginSegment = (ConnectApi.MarkupBeginSegmentInput) segments.get(13);
+        System.assertEquals(ConnectApi.MarkupType.ListItem, markupBeginSegment.markupType);
+
+        markupBeginSegment = (ConnectApi.MarkupBeginSegmentInput) segments.get(14);
+        System.assertEquals(ConnectApi.MarkupType.Underline, markupBeginSegment.markupType);
+
+        textSegment = (ConnectApi.TextSegmentInput) segments.get(15);
+        System.assertEquals(text3, textSegment.text);
+
+        markupEndSegment = (ConnectApi.MarkupEndSegmentInput) segments.get(16);
+        System.assertEquals(ConnectApi.MarkupType.Underline, markupEndSegment.markupType);
+
+        markupEndSegment = (ConnectApi.MarkupEndSegmentInput) segments.get(17);
+        System.assertEquals(ConnectApi.MarkupType.ListItem, markupEndSegment.markupType);
+
+        markupEndSegment = (ConnectApi.MarkupEndSegmentInput) segments.get(18);
+        System.assertEquals(ConnectApi.MarkupType.OrderedList, markupEndSegment.markupType);
+        
+        // <b>And, of course, an image for you:</b> {img:069B0000000q7hi:An image of something nice.}
+        markupBeginSegment = (ConnectApi.MarkupBeginSegmentInput) segments.get(19);
+        System.assertEquals(ConnectApi.MarkupType.Bold, markupBeginSegment.markupType);
+
+        textSegment = (ConnectApi.TextSegmentInput) segments.get(20);
+        System.assertEquals(text4, textSegment.text);
+
+        markupEndSegment = (ConnectApi.MarkupEndSegmentInput) segments.get(21);
+        System.assertEquals(ConnectApi.MarkupType.Bold, markupEndSegment.markupType);
+
+        textSegment = (ConnectApi.TextSegmentInput) segments.get(22);
+        System.assertEquals(text5, textSegment.text);
+
+        ConnectApi.InlineImageSegmentInput inlineImageSegment = (ConnectApi.InlineImageSegmentInput) segments.get(23);
+        System.assertEquals(imageId, inlineImageSegment.fileId);
+        System.assertEquals(altText, inlineImageSegment.altText);
+    }
 }

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ ConnectApiHelper
 `ConnectApiHelper` is an Apex class that makes it easier to do common operations with the classes in the ConnectApi namespace. It includes convenience methods to:
 
 * Post Chatter @-mentions with Apex code.
+* Post rich text and inline images with Apex code.
 * Take a feed item or comment body and return an input body that matches it (useful for either editing or re-posting).
 
 Easier @-mentions
@@ -35,10 +36,53 @@ If you want to mention someone in a post that says: *Hey there @Jane Doe, how ar
 
     ConnectApi.FeedItem fi = ConnectApi.ChatterFeeds.postFeedElement(Network.getNetworkId(), input, null);
 
+Streamlined rich text and inline images
+---------------------------------------
+If you want to add rich text or inline images in your post, one line will do it:
+
+    ConnectApi.FeedItem fi = ConnectApiHelper.postFeedItemWithRichText(Network.getNetworkId(),
+    'me', 'Have you seen this <b>gorgeous</b> view? {img:069x00000000D7m:View of the Space Needle from our office.}');
+
+... instead of this:
+
+    ConnectApi.MessageBodyInput messageInput = new ConnectApi.MessageBodyInput();
+    messageInput.messageSegments = new List<ConnectApi.MessageSegmentInput>();
+
+    ConnectApi.TextSegmentInput textSegment = new ConnectApi.TextSegmentInput();
+    textSegment.text = 'Have you seen this ';
+    messageInput.messageSegments.add(textSegment);
+
+    ConnectApi.MarkupBeginSegmentInput markupBeginSegment = new ConnectApi.MarkupBeginSegmentInput();
+    markupBeginSegment.markupType = ConnectApi.MarkupType.Bold; 
+    messageInput.messageSegments.add(markupBeginSegment);
+
+    textSegment = new ConnectApi.TextSegmentInput();
+    textSegment.text = 'gorgeous';
+    messageInput.messageSegments.add(textSegment);
+
+    ConnectApi.MarkupEndSegmentInput markupEndSegment = new ConnectApi.MarkupEndSegmentInput();
+    markupEndSegment.markupType = ConnectApi.MarkupType.Bold; 
+    messageInput.messageSegments.add(markupEndSegment);
+
+    textSegment = new ConnectApi.TextSegmentInput();
+    textSegment.text = ' view? ';
+    messageInput.messageSegments.add(textSegment);
+
+    ConnectApi.InlineImageSegmentInput inlineImageSegment = new ConnectApi.InlineImageSegmentInput();
+    inlineImageSegment.fileId = '069x00000000D7m';
+    inlineImageSegment.altText = 'View of the Space Needle from our office.';
+    messageInput.messageSegments.add(inlineImageSegment);
+
+    ConnectApi.FeedItemInput input = new ConnectApi.FeedItemInput();
+    input.body = messageInput;
+    input.subjectId = 'me';
+
+    ConnectApi.FeedItem fi = ConnectApi.ChatterFeeds.postFeedElement(Network.getNetworkId(), input, null);
+
 Installation
 ------------
 
-Just copy the `ConnectApiHelper` and `ConnectApiHelperTest` classes to your Salesforce org. For @-mentions, the methods to use are `ConnectApiHelper.postFeedItemWithMentions` and `ConnectApiHelper.postCommentWithMentions` and the parameters and formatting syntax are described in the method comments. You can also refer to the `ConnectApiHelperTest` class for more examples.
+Just copy the `ConnectApiHelper` and `ConnectApiHelperTest` classes to your Salesforce org. For @-mentions, the methods to use are `ConnectApiHelper.postFeedItemWithMentions` and `ConnectApiHelper.postCommentWithMentions` and the parameters and formatting syntax are described in the method comments. To include rich text and inline images as well (starting in version 35.0), the method to use is `ConnectApiHelper.postFeedItemWithRichText`.  You can also refer to the `ConnectApiHelperTest` class for more examples.
 
 For creating input bodies from output bodies, the methods are `ConnectApiHelper.createFeedItemInputFromBody` and `ConnectApiHelper.createCommentInputFromBody`.
 


### PR DESCRIPTION
With API version 35.0, rich text and inline images are available!  Here are more convenient methods for adding them to your posts.