### PR TITLE
Modified use of postFeedElement method for API 36.0

### DIFF
--- a/ConnectApiHelper.cls
+++ b/ConnectApiHelper.cls
@@ -106,7 +106,7 @@ global class ConnectApiHelper {
         input.body = messageInput;
         input.subjectId = subjectId;
         
-        return ConnectApi.ChatterFeeds.postFeedElement(communityId, input, null);
+        return ConnectApi.ChatterFeeds.postFeedElement(communityId, input);
     }
 
     /**


### PR DESCRIPTION
36.0 of the API no longer supports file upload argument in the postFeedElement method.  So, removed the third parameter, which was null anyway.
